### PR TITLE
Update http.py

### DIFF
--- a/lib/common/http.py
+++ b/lib/common/http.py
@@ -13,7 +13,7 @@ These are the first places URI requests are processed.
 from BaseHTTPServer import BaseHTTPRequestHandler
 import BaseHTTPServer, threading, ssl, os, re
 from pydispatch import dispatcher
-
+import socket
 # EmPyre imports
 import helpers
 
@@ -146,8 +146,11 @@ class EmPyreServer(threading.Thread):
         try:
             threading.Thread.__init__(self)
             self.server = None
-
-            self.server = BaseHTTPServer.HTTPServer((lhost, int(port)), RequestHandler)
+            try:
+                self.server = BaseHTTPServer.HTTPServer((lhost, int(port)), RequestHandler)
+            except socket.error::
+                dispatcher.send("[!] Error starting listener on IP address "+lhost+", trying 0.0.0.0 ...", sender="EmPyreServer")
+                self.server = BaseHTTPServer.HTTPServer(("0.0.0.0", int(port)), RequestHandler)
 
             # pass the agent handler object along for the RequestHandler
             self.server.agents = handler


### PR DESCRIPTION
Hello,
Sometimes, we need to listen on the public server and redirect the traffic into our empire listener on the internal server using DNAT, we would like to set the listeners "Host" to the public IP address while listening on the internal server. This way, all the stager payloads would contain the public IP address while the EmPyre instance turns on the local machine. This pull request would allow us to implement this scenario.
On the empire powershell project, the listener listens by default to the 0.0.0.0 IP address (https://github.com/PowerShellEmpire/Empire/blob/e43fb9463410dfa804e0aa507a5842c1a0504c0d/lib/common/http.py#L150).